### PR TITLE
fix: Fix bug can not refresh with old session token

### DIFF
--- a/frontend/public/i18n/en.json
+++ b/frontend/public/i18n/en.json
@@ -89,7 +89,9 @@
       "not-confirm": "Email not confirmed. Please check your inbox.",
       "user-not-exist": "This email address does not exist in the system. Please check your email or register for a new account.",
       "invalid-credentials": "The email address or password you entered is incorrect. Please check and try again.",
-      "token-expired": "The link has expired. A new one has been sent to your email."
+      "token-expired": "The link has expired. A new one has been sent to your email.",
+      "user-already-confirmed": "This account is already confirmed. Please log in to continue.",
+      "still-have-session": "You have an active session. Please log out to access a new account."
     },
     "register": {
       "header": "Register",

--- a/frontend/public/i18n/vi.json
+++ b/frontend/public/i18n/vi.json
@@ -89,7 +89,9 @@
       "not-confirm": "Email chưa được xác nhận. Vui lòng kiểm tra hộp thư.",
       "user-not-exist": "Địa chỉ email này không tồn tại trong hệ thống. Vui lòng kiểm tra lại email hoặc đăng ký tài khoản mới.",
       "invalid-credentials": "Email hoặc mật khẩu bạn nhập không đúng. Vui lòng kiểm tra và thử lại.",
-      "token-expired": "Liên kết đã hết hạn. Một liên kết mới đã được gửi đến email của bạn."
+      "token-expired": "Liên kết đã hết hạn. Một liên kết mới đã được gửi đến email của bạn.",
+      "user-already-confirmed": "Người dùng này đã được xác nhận. Vui lòng đăng nhập vào tài khoản của bạn.",
+      "still-have-session": "Bạn đang có phiên đăng nhập. Vui lòng đăng xuất để truy cập tài khoản mới."
     },
     "register": {
       "header": "Đăng ký",

--- a/frontend/src/app/core/auth/auth.guard.ts
+++ b/frontend/src/app/core/auth/auth.guard.ts
@@ -5,7 +5,7 @@ import { AuthService } from './auth.service';
 import { ToastHandlingService } from '../../shared/services/toast-handling.service';
 
 /**
- * Auth guard to protect routes that require authentication.
+ * Guard to protect routes that require authentication.
  *
  * - Checks if the user is logged in using `AuthService.isLoggedIn()`.
  * - If not logged in, redirects to `/auth/login` and prevents access.
@@ -13,10 +13,10 @@ import { ToastHandlingService } from '../../shared/services/toast-handling.servi
  * @returns {boolean} `true` if the user is authenticated, otherwise `false`.
  */
 export const authGuard: CanMatchFn = () => {
+  const router = inject(Router);
   const authService = inject(AuthService);
 
   if (!authService.isLoggedIn()) {
-    const router = inject(Router);
     router.navigate(['/auth/login']);
     return false;
   }
@@ -35,14 +35,36 @@ export const authGuard: CanMatchFn = () => {
 export const resetPasswordGuard: CanMatchFn = () => {
   const router = inject(Router);
   const toastHandlingService = inject(ToastHandlingService);
-  const queryParams = new URLSearchParams(location.search);
 
+  const queryParams = new URLSearchParams(location.search);
   const token = queryParams.get('token');
   const email = queryParams.get('email');
 
   if (!token || !email) {
     toastHandlingService.handleWarning('auth.reset.invalid-token');
     router.navigate(['/auth/forgot-password']);
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Guard to protect login and register routes.
+ *
+ * - Checks if the user is logged in using `AuthService.isLoggedIn()`.
+ * - If logged in, redirects to `/home`.
+ *
+ * @returns {boolean} `true` if the user is authenticated, otherwise `false`.
+ */
+export const loggedInGuard: CanMatchFn = () => {
+  const router = inject(Router);
+  const authService = inject(AuthService);
+  const toastHandlingService = inject(ToastHandlingService);
+
+  if (authService.isLoggedIn()) {
+    toastHandlingService.handleWarning('auth.login.still-have-session');
+    router.navigate(['/home']);
     return false;
   }
 

--- a/frontend/src/app/core/auth/auth.routes.ts
+++ b/frontend/src/app/core/auth/auth.routes.ts
@@ -1,15 +1,17 @@
 import { Routes } from '@angular/router';
 
-import { resetPasswordGuard } from './auth.guard';
+import { loggedInGuard, resetPasswordGuard } from './auth.guard';
 
 export const authRoutes: Routes = [
   {
     path: 'login',
+    canMatch: [loggedInGuard],
     loadComponent: () =>
       import('./pages/login/login.component').then((mod) => mod.LoginComponent),
   },
   {
     path: 'register',
+    canMatch: [loggedInGuard],
     loadComponent: () =>
       import('./pages/register/register.component').then(
         (mod) => mod.RegisterComponent,
@@ -17,6 +19,7 @@ export const authRoutes: Routes = [
   },
   {
     path: 'forgot-password',
+    canMatch: [loggedInGuard],
     loadComponent: () =>
       import('./pages/forgot-password/forgot-password.component').then(
         (mod) => mod.ForgotPasswordComponent,

--- a/frontend/src/app/core/auth/auth.service.ts
+++ b/frontend/src/app/core/auth/auth.service.ts
@@ -41,6 +41,7 @@ import {
   RESET_PASSWORD_SUCCESS_CODE,
   SUCCESS_CODE,
   TOKEN_EXPIRED_CODE,
+  USER_ALREADY_CONFIRMED,
   USER_NOT_EXIST_CODE,
 } from '../../shared/constants/status-code-constants';
 
@@ -223,7 +224,12 @@ export class AuthService {
           this.toastHandlingService.handleCommonError();
         }
       }),
-      catchError(() => {
+      catchError((error: HttpErrorResponse) => {
+        if (error.error.statusCode === USER_ALREADY_CONFIRMED) {
+          this.toastHandlingService.handleWarning(
+            'auth.login.user-already-confirmed',
+          );
+        }
         this.toastHandlingService.handleCommonError();
         return of(undefined);
       }),

--- a/frontend/src/app/core/interceptors/api.interceptor.ts
+++ b/frontend/src/app/core/interceptors/api.interceptor.ts
@@ -70,6 +70,7 @@ export const apiInterceptor: HttpInterceptorFn = (req, next) => {
         return next(clonedRequest);
       }),
       catchError((error) => {
+        authService.deleteToken();
         router.navigate(['/auth/login']);
         return throwError(() => error);
       }),

--- a/frontend/src/app/modules/user/pages/profile/profile.service.ts
+++ b/frontend/src/app/modules/user/pages/profile/profile.service.ts
@@ -6,7 +6,10 @@ import { environment } from '../../../../../environments/environment';
 import { SUCCESS_CODE } from '../../../../shared/constants/status-code-constants';
 
 import type { BaseResponseModel } from '../../../../shared/models/api/base-response.model';
-import type { UserModel, UserUpdateModel } from '../../../../shared/models/entities/user.model';
+import type {
+  UserModel,
+  UserUpdateModel,
+} from '../../../../shared/models/entities/user.model';
 import { SUBSCRIPTIONS } from '../../../../shared/constants/subscription-constant';
 import { IndustryModel } from '../../../../shared/models/entities/industry.model';
 import { WardModel } from '../../../../shared/models/entities/location.model';
@@ -45,13 +48,15 @@ export class ProfileService {
         map((res) => {
           if (res.statusCode === SUCCESS_CODE && res.data) {
             this.userSignal.set(res.data);
-            this.subscriptionSignal.set(SUBSCRIPTIONS[res.data.subscriptionPlan]);
+            this.subscriptionSignal.set(
+              SUBSCRIPTIONS[res.data.subscriptionPlan],
+            );
           } else {
             this.userSignal.set(null);
           }
         }),
         catchError(() => of(undefined)),
-        finalize(() => this.loadingSignal.set(false))
+        finalize(() => this.loadingSignal.set(false)),
       );
   }
 
@@ -59,7 +64,7 @@ export class ProfileService {
     updatedProfile: Partial<UserUpdateModel>,
     industries: IndustryModel[],
     wards: WardModel[],
-    user: UserModel
+    user: UserModel,
   ): Observable<boolean> {
     this.loadingSignal.set(true);
     const filteredProfile = this.filterEmptyValues(updatedProfile);
@@ -75,16 +80,19 @@ export class ProfileService {
           return false;
         }),
         catchError(() => of(false)),
-        finalize(() => this.loadingSignal.set(false))
+        finalize(() => this.loadingSignal.set(false)),
       );
   }
 
   getJobPostsByUserId(isOwner: boolean, userId: string): Observable<void> {
     this.loadingSignal.set(true);
     return this.httpClient
-      .get<BaseResponseModel<JobPostModel | JobPostModel[]>>(`${this.JOB_POSTS_API_URL}/${userId}`, {
-        params: createHttpParams({ isOwner }),
-      })
+      .get<BaseResponseModel<JobPostModel | JobPostModel[]>>(
+        `${this.JOB_POSTS_API_URL}/${userId}`,
+        {
+          params: createHttpParams({ isOwner }),
+        },
+      )
       .pipe(
         map((res) => {
           if (res.statusCode === SUCCESS_CODE && res.data) {
@@ -92,21 +100,22 @@ export class ProfileService {
             const jobPosts = Array.isArray(res.data) ? res.data : [res.data];
             this.jobsSignal.set(jobPosts);
           } else {
-            this.jobsSignal.set([]); 
+            this.jobsSignal.set([]);
           }
         }),
         catchError(() => {
           this.jobsSignal.set([]);
           return of(undefined);
         }),
-        finalize(() => this.loadingSignal.set(false))
+        finalize(() => this.loadingSignal.set(false)),
       );
   }
-  
 
-  private filterEmptyValues(profile: Partial<UserUpdateModel>): Partial<UserUpdateModel> {
+  private filterEmptyValues(
+    profile: Partial<UserUpdateModel>,
+  ): Partial<UserUpdateModel> {
     return Object.fromEntries(
-      Object.entries(profile).filter(([, value]) => value !== '')
+      Object.entries(profile).filter(([, value]) => value !== ''),
     );
   }
 
@@ -114,7 +123,7 @@ export class ProfileService {
     updatedProfile: Partial<UserUpdateModel>,
     industries: IndustryModel[],
     wards: WardModel[],
-    user: UserModel
+    user: UserModel,
   ): void {
     const transformedData = this.transformData(updatedProfile, industries, wards, user);
     const currentUser = this.userSignal();
@@ -127,18 +136,26 @@ export class ProfileService {
     input: Partial<UserUpdateModel>,
     industries: IndustryModel[],
     wards: WardModel[],
-    user: UserModel
+    user: UserModel,
   ): Partial<UserModel> {
     const { majorIndustryId, wardId, cityId, ...rest } = input;
 
     const majorIndustry =
       majorIndustryId !== undefined
-        ? industries.find((ind) => ind.id === majorIndustryId)?.industryName ?? 'Unknown'
+        ? (industries.find((ind) => ind.id === majorIndustryId)?.industryName ??
+          'Unknown')
         : user.majorIndustry;
+
+    const cityName =
+      cityId !== undefined
+        ? (cities.find((city) => city.id === cityId)?.name ??
+          'Unknown Location')
+        : user.city;
 
     const fullLocation =
       cityId && wardId
-        ? wards.find((ward) => ward.id === wardId)?.fullLocation ?? 'Unknown Location'
+        ? (wards.find((ward) => ward.id === wardId)?.fullLocation ??
+          'Unknown Location')
         : user.fullLocation;
 
     return { ...rest, majorIndustry, fullLocation };

--- a/frontend/src/app/modules/user/pages/profile/profile.service.ts
+++ b/frontend/src/app/modules/user/pages/profile/profile.service.ts
@@ -125,7 +125,12 @@ export class ProfileService {
     wards: WardModel[],
     user: UserModel,
   ): void {
-    const transformedData = this.transformData(updatedProfile, industries, wards, user);
+    const transformedData = this.transformData(
+      updatedProfile,
+      industries,
+      wards,
+      user,
+    );
     const currentUser = this.userSignal();
     if (currentUser) {
       this.userSignal.set({ ...currentUser, ...transformedData });
@@ -145,12 +150,6 @@ export class ProfileService {
         ? (industries.find((ind) => ind.id === majorIndustryId)?.industryName ??
           'Unknown')
         : user.majorIndustry;
-
-    const cityName =
-      cityId !== undefined
-        ? (cities.find((city) => city.id === cityId)?.name ??
-          'Unknown Location')
-        : user.city;
 
     const fullLocation =
       cityId && wardId

--- a/frontend/src/app/shared/constants/status-code-constants.ts
+++ b/frontend/src/app/shared/constants/status-code-constants.ts
@@ -20,6 +20,7 @@ export const NOT_CONFIRM_CODE = 2005;
 export const INVALID_CREDENTIAL_CODE = 2006;
 export const INVALID_TOKEN = 2007;
 export const TOKEN_EXPIRED_CODE = 2008;
+export const USER_ALREADY_CONFIRMED = 2009;
 
 // ? Jobs Code
 export const USER_NOT_ENOUGH_BALANCE = 2023;

--- a/frontend/src/app/shared/utils/request-utils.ts
+++ b/frontend/src/app/shared/utils/request-utils.ts
@@ -1,6 +1,10 @@
-import { HttpErrorResponse, HttpParams, HttpRequest } from "@angular/common/http";
-import { Router } from "@angular/router";
-import { Observable, throwError, timer } from "rxjs";
+import {
+  HttpErrorResponse,
+  HttpParams,
+  HttpRequest,
+} from '@angular/common/http';
+import { Router } from '@angular/router';
+import { Observable, throwError, timer } from 'rxjs';
 
 /**
  * Converts an object of key-value pairs into an HttpParams instance.
@@ -10,14 +14,14 @@ import { Observable, throwError, timer } from "rxjs";
  * @returns An instance of HttpParams with the provided key-value pairs.
  */
 export function createHttpParams(params: Record<string, any>): HttpParams {
-    let httpParams = new HttpParams();
-    Object.keys(params).forEach(key => {
-        const value = params[key];
-        if (value !== null && value !== undefined) {
-        httpParams = httpParams.append(key, value.toString());
-        }
-    });
-    return httpParams;
+  let httpParams = new HttpParams();
+  Object.keys(params).forEach((key) => {
+    const value = params[key];
+    if (value !== null && value !== undefined) {
+      httpParams = httpParams.append(key, value.toString());
+    }
+  });
+  return httpParams;
 }
 
 /**
@@ -27,11 +31,14 @@ export function createHttpParams(params: Record<string, any>): HttpParams {
  * @param token - The access token to include in the Authorization header.
  * @returns A new HTTP request with the Authorization header added.
  */
-export function addAuthHeader(req: HttpRequest<unknown>, token: string | null): HttpRequest<unknown> {
-    return req.clone({
-      headers: req.headers.set('Authorization', `Bearer ${token ?? ''}`)
-    });
-};
+export function addAuthHeader(
+  req: HttpRequest<unknown>,
+  token: string | null,
+): HttpRequest<unknown> {
+  return req.clone({
+    headers: req.headers.set('Authorization', `Bearer ${token ?? ''}`),
+  });
+}
 
 /**
  * Handles unauthorized HTTP errors (401) by redirecting the user to the login page.
@@ -40,14 +47,14 @@ export function addAuthHeader(req: HttpRequest<unknown>, token: string | null): 
  * @returns A function that processes the error and navigates to the login page if the status is 401.
  */
 export function handleUnauthorizedError(router: Router) {
-    return (error: HttpErrorResponse) => {
-        if (error.status === 401) {
-        router.navigate(['/auth/login']);
-        }
-        return throwError(() => error);
-    };
-};
-  
+  return (error: HttpErrorResponse) => {
+    if (error.status === 401) {
+      router.navigate(['/auth/login']);
+    }
+    return throwError(() => error);
+  };
+}
+
 /**
  * A retry strategy that implements exponential backoff for network errors or 5xx server errors.
  *
@@ -56,18 +63,18 @@ export function handleUnauthorizedError(router: Router) {
  * @returns An Observable that delays the retry based on the retry strategy or throws the error.
  */
 export function retryStrategy(error: any, retryCount: number): Observable<any> {
-    const delayMs = Math.min(1000 * Math.pow(2, retryCount), 10000);
+  const delayMs = Math.min(1000 * Math.pow(2, retryCount), 10000);
 
-    // ? Only retry on network errors or 5xx internal server errors
-    if (error instanceof HttpErrorResponse) {
-        if (error.status === 0 || (error.status >= 500 && error.status < 600)) {
-            return timer(delayMs);
-        }
+  // ? Only retry on network errors or 5xx internal server errors
+  if (error instanceof HttpErrorResponse) {
+    if (error.status === 0 || (error.status >= 500 && error.status < 600)) {
+      return timer(delayMs);
     }
+  }
 
-    return throwError(() => error);
-};
-  
+  return throwError(() => error);
+}
+
 /**
  * Checks if a URL is public and does not require authentication.
  *
@@ -75,12 +82,12 @@ export function retryStrategy(error: any, retryCount: number): Observable<any> {
  * @returns A boolean indicating whether the URL is public.
  */
 export function isPublicPath(url: string): boolean {
-    const publicPaths = new Set<string>([
-        '/auth/login',
-        '/auth/register',
-        '/jobs',
-        // ? Can add more endpoints here
-    ]);
+  const publicPaths = new Set<string>([
+    '/auth/login',
+    '/auth/register',
+    '/jobs',
+    // ? Can add more endpoints here
+  ]);
 
-    return Array.from(publicPaths).some(path => url.includes(path));
-};
+  return Array.from(publicPaths).some((path) => url.includes(path));
+}


### PR DESCRIPTION
- Before: If user logged in then user still can redirect to authentication pages lead to error with refresh token API
- After: If user logged in then user can not redirect to authentication pages, user redirected to home page and have notify for user know that have to log out to access to a new account